### PR TITLE
Fix indexing errors in Python implementation

### DIFF
--- a/kdtw.py
+++ b/kdtw.py
@@ -105,9 +105,35 @@ def Dlpr(a, b, sigma=1, epsilon=1e-3):
     return (np.exp(-np.sum((a - b) ** 2) / sigma) + epsilon) / (3 * (1 + epsilon))
 
 
+def compare_to_matlab():
+    # parameters
+    gamma = 0.125
+    epsilon = 1e-20
+
+    # Univariate case
+    x = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float).reshape(-1, 1)
+    y = np.array([5, 6, 7, 8, 9, 1, 2], dtype=float).reshape(-1, 1)
+    expected_distance = 1.2814254453822292e-102
+
+    distance = kdtw(x, y, sigma=gamma, epsilon=epsilon)
+    np.testing.assert_almost_equal(distance, expected_distance, decimal=112)
+
+    # multivariate case
+    x = np.array(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 2, 1, 2, 3, 2, 1]], dtype=float
+    ).T
+    y = np.array([[5, 6, 7, 8, 9, 1, 2], [5, 6, 7, 8, 7, 6, 5]], dtype=float).T
+    expected_distance = 1.828989485754932e-183
+
+    distance = kdtw(x, y, sigma=gamma, epsilon=epsilon)
+    np.testing.assert_almost_equal(distance, expected_distance, decimal=193)
+
+
 # Simple test
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
+
+    compare_to_matlab()
 
     A = np.array([[0], [0], [1], [1], [2], [3], [5], [2], [0], [1], [-0.1]])
     B = np.array(

--- a/kdtw.py
+++ b/kdtw.py
@@ -53,7 +53,7 @@ def kdtw(A, B, sigma=1, epsilon=1e-3):
     DP1 = np.zeros((la, lb))
     DP2 = np.zeros(max(la, lb))
     l = min(la, lb)
-    DP2[1] = 1.0
+    DP2[0] = 1.0
     for i in range(1, l):
         DP2[i] = Dlpr(A[i], B[i], sigma, epsilon)
     if la < lb:
@@ -69,12 +69,12 @@ def kdtw(A, B, sigma=1, epsilon=1e-3):
     m = len(B)
 
     for i in range(1, n):
-        DP[i, 1] = DP[i - 1, 1] * Dlpr(A[i], B[2], sigma, epsilon)
-        DP1[i, 1] = DP1[i - 1, 1] * DP2[i]
+        DP[i, 0] = DP[i - 1, 0] * Dlpr(A[i], B[0], sigma, epsilon)
+        DP1[i, 0] = DP1[i - 1, 0] * DP2[i]
 
     for j in range(1, m):
-        DP[1, j] = DP[1, j - 1] * Dlpr(A[2], B[j], sigma, epsilon)
-        DP1[1, j] = DP1[1, j - 1] * DP2[j]
+        DP[0, j] = DP[0, j - 1] * Dlpr(A[0], B[j], sigma, epsilon)
+        DP1[0, j] = DP1[0, j - 1] * DP2[j]
 
     for i in range(1, n):
         for j in range(1, m):

--- a/kdtw.py
+++ b/kdtw.py
@@ -35,12 +35,15 @@ import numpy as np
 
 
 def kdtw(A, B, sigma=1, epsilon=1e-3):
-    """
-    # Dynamic programming implementation of KDTW kernel
-    # input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-    # intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-    # input sigma: >0 used in the exponential local kernel
-    # output similarity: similarity between A and B (the higher, the more similar)
+    """Dynamic programming implementation of KDTW kernel
+
+    :param A: first multivariate time series: array of array (n x d), n is the number
+              of samples, d is the dimension of each sample
+    :param B: second multivariate time series: array of array (n x d), n is the number
+              of samples, d is the dimension of each sample
+    :param sigma: must be >0; used in the exponential local kernel
+    :param epsilon: must be 1 > epsilon > 0, used in the exponential local kernel
+    :return: similarity between A and B (the higher, the more similar)
     """
     d = np.shape(A)[1]
     Z = [np.zeros(d)]

--- a/kdtw.py
+++ b/kdtw.py
@@ -5,18 +5,19 @@ Created on Sun Sep 27 16:46:45 2020
 @author: pfm
 """
 import numpy as np
+
 # Filename: kdtw.py
 # Python source code for the "Kernelized" Dynamic Time Warping similarity (as defined in the reference below).
 # Author: Pierre-Francois Marteau
-# Version: V1.0 du 13/09/2014, 
+# Version: V1.0 du 13/09/2014,
 # Licence: GPL
 # ******************************************************************
-# This software and description is free delivered "AS IS" with no 
-# guaranties for work at all. Its up to you testing it modify it as 
-# you like, but no help could be expected from me due to lag of time 
-# at the moment. I will answer short relevant questions and help as 
-# my time allow it. I have tested it played with it and found no 
-# problems in stability or malfunctions so far. 
+# This software and description is free delivered "AS IS" with no
+# guaranties for work at all. Its up to you testing it modify it as
+# you like, but no help could be expected from me due to lag of time
+# at the moment. I will answer short relevant questions and help as
+# my time allow it. I have tested it played with it and found no
+# problems in stability or malfunctions so far.
 # Have fun.
 # *****************************************************************
 # Please cite as:
@@ -30,85 +31,109 @@ import numpy as np
 #   KEYWORDS = {Elastic distance, Time warp kernel, Time warp inner product, Definiteness, Time series classification, SVM},
 #   DOI = {10.1109/TNNLS.2014.2333876},
 #   URL = {http://hal.inria.fr/hal-00486916}
-# } 
-# 
-''''
-# function kdtw(A, B, sigma, epsilon=1e-3)
-# Dynamic programming implementation of KDTW kernel
-# input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# input sigma: >0 used in the exponential local kernel 
-# output similarity: similarity between A and B (the higher, the more similar)
-'''
-def kdtw(A, B, sigma = 1, epsilon = 1e-3):
-    d=np.shape(A)[1]
-    Z=[np.zeros(d)]
-    A = np.concatenate((Z,A), axis = 0)
-    B = np.concatenate((Z,B), axis = 0)
-    [la,d] = np.shape(A)
-    [lb,d] = np.shape(B)
+# }
 
-    DP = np.zeros((la,lb))
-    DP1 = np.zeros((la,lb));
-    DP2 = np.zeros(max(la,lb));
-    l=min(la,lb);
-    DP2[1] = 1.0;
-    for i in range(1,l):
-        DP2[i] = Dlpr(A[i],B[i], sigma, epsilon);
-    if la<lb:
-        for i in range(la,lb):
-            DP2[i] = Dlpr(A[la-1],B[i], sigma, epsilon);
-    elif lb<la:
-        for i in range(lb,la):
-            DP2[i] = Dlpr(A[i],B[lb-i], sigma, epsilon);
 
-    DP[0,0] = 1;
-    DP1[0,0] = 1;
-    n = len(A);
-    m = len(B);
+def kdtw(A, B, sigma=1, epsilon=1e-3):
+    """
+    # Dynamic programming implementation of KDTW kernel
+    # input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # input sigma: >0 used in the exponential local kernel
+    # output similarity: similarity between A and B (the higher, the more similar)
+    """
+    d = np.shape(A)[1]
+    Z = [np.zeros(d)]
+    A = np.concatenate((Z, A), axis=0)
+    B = np.concatenate((Z, B), axis=0)
+    [la, d] = np.shape(A)
+    [lb, d] = np.shape(B)
 
-    for i in range(1,n):
-        DP[i,1] = DP[i-1,1]*Dlpr(A[i], B[2], sigma, epsilon);
-        DP1[i,1] = DP1[i-1,1]*DP2[i];
+    DP = np.zeros((la, lb))
+    DP1 = np.zeros((la, lb))
+    DP2 = np.zeros(max(la, lb))
+    l = min(la, lb)
+    DP2[1] = 1.0
+    for i in range(1, l):
+        DP2[i] = Dlpr(A[i], B[i], sigma, epsilon)
+    if la < lb:
+        for i in range(la, lb):
+            DP2[i] = Dlpr(A[la - 1], B[i], sigma, epsilon)
+    elif lb < la:
+        for i in range(lb, la):
+            DP2[i] = Dlpr(A[i], B[lb - i], sigma, epsilon)
 
-    for j in range(1,m):
-        DP[1,j] = DP[1,j-1]*Dlpr(A[2], B[j], sigma, epsilon);
-        DP1[1,j] = DP1[1,j-1]*DP2[j];
+    DP[0, 0] = 1
+    DP1[0, 0] = 1
+    n = len(A)
+    m = len(B)
 
-    for i in range(1,n):
-        for j in range(1,m): 
-            lcost = Dlpr(A[i], B[j], sigma, epsilon);
-            DP[i,j] = (DP[i-1,j] + DP[i,j-1] + DP[i-1,j-1])*lcost;
+    for i in range(1, n):
+        DP[i, 1] = DP[i - 1, 1] * Dlpr(A[i], B[2], sigma, epsilon)
+        DP1[i, 1] = DP1[i - 1, 1] * DP2[i]
+
+    for j in range(1, m):
+        DP[1, j] = DP[1, j - 1] * Dlpr(A[2], B[j], sigma, epsilon)
+        DP1[1, j] = DP1[1, j - 1] * DP2[j]
+
+    for i in range(1, n):
+        for j in range(1, m):
+            lcost = Dlpr(A[i], B[j], sigma, epsilon)
+            DP[i, j] = (DP[i - 1, j] + DP[i, j - 1] + DP[i - 1, j - 1]) * lcost
             if i == j:
-                DP1[i,j] = DP1[i-1,j-1]*lcost + DP1[i-1,j]*DP2[i] + DP1[i,j-1]*DP2[j]
+                DP1[i, j] = (
+                    DP1[i - 1, j - 1] * lcost
+                    + DP1[i - 1, j] * DP2[i]
+                    + DP1[i, j - 1] * DP2[j]
+                )
             else:
-                DP1[i,j] = DP1[i-1,j]*DP2[i] + DP1[i,j-1]*DP2[j];
-    DP = DP + DP1;
-    return DP[n-1,m-1]
- 
-# local similarity between two samples
-# a: 1d numpy array 
-# b: 1d numpy array 
-# input sigma: >0 used in the exponential local kernel 
-# input epsilon: 1 > epsilon > 0
-# return the local matching similarity (probability) 
-def Dlpr(a, b, sigma = 1, epsilon = 1e-3):
-    return (np.exp(-np.sum((a - b)**2) / sigma) + epsilon)/(3*(1+epsilon))
+                DP1[i, j] = DP1[i - 1, j] * DP2[i] + DP1[i, j - 1] * DP2[j]
+    DP = DP + DP1
+    return DP[n - 1, m - 1]
+
+
+def Dlpr(a, b, sigma=1, epsilon=1e-3):
+    # local similarity between two samples
+    # a: 1d numpy array
+    # b: 1d numpy array
+    # input sigma: >0 used in the exponential local kernel
+    # input epsilon: 1 > epsilon > 0
+    # return the local matching similarity (probability)
+    return (np.exp(-np.sum((a - b) ** 2) / sigma) + epsilon) / (3 * (1 + epsilon))
+
 
 # Simple test
-if __name__ == '__main__':
+if __name__ == "__main__":
     import matplotlib.pyplot as plt
-    A = np.array([[0],[0],[1],[1],[2],[3],[5],[2],[0],[1],[-0.1]])
-    B = np.array([[0],[1],[2],[2.5],[3],[3.5],[4],[4.5],[5.5],[2],[0],[0],[.25],[.05],[0]])
-    C = np.array([[4],[4],[3],[3],[3],[3],[2],[5],[2],[.5],[.5],[.5]])
-    
-    print("kdtw(A,B)=", kdtw(A,B,1))
-    print("kdtw(A,C)=", kdtw(A,C,1))
-    print("kdtw(B,C)=", kdtw(B,C,1))
-        
-    plt.plot(A, label='A')
-    plt.plot(B, label='B')
-    plt.plot(C, label='C')
+
+    A = np.array([[0], [0], [1], [1], [2], [3], [5], [2], [0], [1], [-0.1]])
+    B = np.array(
+        [
+            [0],
+            [1],
+            [2],
+            [2.5],
+            [3],
+            [3.5],
+            [4],
+            [4.5],
+            [5.5],
+            [2],
+            [0],
+            [0],
+            [0.25],
+            [0.05],
+            [0],
+        ]
+    )
+    C = np.array([[4], [4], [3], [3], [3], [3], [2], [5], [2], [0.5], [0.5], [0.5]])
+
+    print("kdtw(A,B)=", kdtw(A, B, 1))
+    print("kdtw(A,C)=", kdtw(A, C, 1))
+    print("kdtw(B,C)=", kdtw(B, C, 1))
+
+    plt.plot(A, label="A")
+    plt.plot(B, label="B")
+    plt.plot(C, label="C")
     plt.legend()
     plt.show()
-    

--- a/kdtw_cdist.py
+++ b/kdtw_cdist.py
@@ -52,7 +52,7 @@ def kdtw_lk(A, B, local_kernel):
     DP1 = np.zeros((la, lb))
     DP2 = np.zeros(max(la, lb))
     l = min(la, lb)
-    DP2[1] = 1.0
+    DP2[0] = 1.0
     for i in range(1, l):
         DP2[i] = local_kernel[i - 1, i - 1]
 
@@ -62,12 +62,12 @@ def kdtw_lk(A, B, local_kernel):
     m = len(B)
 
     for i in range(1, n):
-        DP[i, 1] = DP[i - 1, 1] * local_kernel[i - 1, 2]
-        DP1[i, 1] = DP1[i - 1, 1] * DP2[i]
+        DP[i, 0] = DP[i - 1, 0] * local_kernel[i - 1, 0]
+        DP1[i, 0] = DP1[i - 1, 0] * DP2[i]
 
     for j in range(1, m):
-        DP[1, j] = DP[1, j - 1] * local_kernel[2, j - 1]
-        DP1[1, j] = DP1[1, j - 1] * DP2[j]
+        DP[0, j] = DP[0, j - 1] * local_kernel[0, j - 1]
+        DP1[0, j] = DP1[0, j - 1] * DP2[j]
 
     for i in range(1, n):
         for j in range(1, m):

--- a/kdtw_cdist.py
+++ b/kdtw_cdist.py
@@ -81,19 +81,21 @@ def kdtw_lk(A, B, local_kernel):
                 )
             else:
                 DP1[i, j] = DP1[i - 1, j] * DP2[i] + DP1[i, j - 1] * DP2[j]
+
     DP = DP + DP1
     return DP[n - 1, m - 1]
 
 
 def kdtw(A, B, sigma=1.0, epsilon=1e-3):
-    """
-    # function kdtw(A, B, sigma, epsilon)
-    # Dynamic programming implementation of KDTW kernel
-    # input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-    # intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-    # input sigma: >0, used in the exponential local kernel
-    # input epsilon: 1 > epsilon > 0, used in the exponential local kernel
-    # output similarity: similarity between A and B (the higher, the more similar)
+    """Dynamic programming implementation of KDTW kernel
+
+    :param A: first multivariate time series: array of array (n x d), n is the number
+              of samples, d is the dimension of each sample
+    :param B: second multivariate time series: array of array (n x d), n is the number
+              of samples, d is the dimension of each sample
+    :param sigma: must be >0; used in the exponential local kernel
+    :param epsilon: must be 1 > epsilon > 0, used in the exponential local kernel
+    :return: similarity between A and B (the higher, the more similar)
     """
     distance = cdist(A, B, "sqeuclidean")
     local_kernel = (np.exp(-distance / sigma) + epsilon) / (3 * (1 + epsilon))

--- a/kdtw_cdist.py
+++ b/kdtw_cdist.py
@@ -102,9 +102,34 @@ def kdtw(A, B, sigma=1.0, epsilon=1e-3):
     return kdtw_lk(A, B, local_kernel)
 
 
+def compare_to_matlab():
+    # parameters
+    gamma = 0.125
+    epsilon = 1e-20
+
+    # Univariate case
+    x = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float).reshape(-1, 1)
+    y = np.array([5, 6, 7, 8, 9, 1, 2], dtype=float).reshape(-1, 1)
+    expected_distance = 1.2814254453822292e-102
+
+    distance = kdtw(x, y, sigma=gamma, epsilon=epsilon)
+    np.testing.assert_almost_equal(distance, expected_distance, decimal=112)
+
+    # multivariate case
+    x = np.array(
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 2, 1, 2, 3, 2, 1]], dtype=float
+    ).T
+    y = np.array([[5, 6, 7, 8, 9, 1, 2], [5, 6, 7, 8, 7, 6, 5]], dtype=float).T
+    expected_distance = 1.828989485754932e-183
+
+    distance = kdtw(x, y, sigma=gamma, epsilon=epsilon)
+    np.testing.assert_almost_equal(distance, expected_distance, decimal=193)
+
 # Simple test
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
+
+    compare_to_matlab()
 
     A = np.array([[0], [0], [1], [1], [2], [3], [5], [2], [0], [1], [-0.1]])
     B = np.array(

--- a/kdtw_cdist.py
+++ b/kdtw_cdist.py
@@ -7,18 +7,19 @@ Created on Sun Sep 27 16:46:45 2020
 """
 from scipy.spatial.distance import cdist
 import numpy as np
+
 # Filename: kdtw_cdist.py
 # Python source code for the "Kernelized" Dynamic Time Warping similarity (as defined in the reference below).
 # Author: Pierre-Francois Marteau
-# Version: V1.0 du 13/09/2014, 
+# Version: V1.0 du 13/09/2014,
 # Licence: GPL
 # ******************************************************************
-# This software and description is free delivered "AS IS" with no 
-# guaranties for work at all. Its up to you testing it modify it as 
-# you like, but no help could be expected from me due to lag of time 
-# at the moment. I will answer short relevant questions and help as 
-# my time allow it. I have tested it played with it and found no 
-# problems in stability or malfunctions so far. 
+# This software and description is free delivered "AS IS" with no
+# guaranties for work at all. Its up to you testing it modify it as
+# you like, but no help could be expected from me due to lag of time
+# at the moment. I will answer short relevant questions and help as
+# my time allow it. I have tested it played with it and found no
+# problems in stability or malfunctions so far.
 # Have fun.
 # *****************************************************************
 # Please cite as:
@@ -32,83 +33,105 @@ import numpy as np
 #   KEYWORDS = {Elastic distance, Time warp kernel, Time warp inner product, Definiteness, Time series classification, SVM},
 #   DOI = {10.1109/TNNLS.2014.2333876},
 #   URL = {http://hal.inria.fr/hal-00486916}
-# } 
-# 
-'''
-# input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# input local_kernel: matrix of local kernel evaluations
-'''
+# }
+
+
 def kdtw_lk(A, B, local_kernel):
-    d=np.shape(A)[1]
-    Z=[np.zeros(d)]
-    A = np.concatenate((Z,A), axis=0)
-    B = np.concatenate((Z,B), axis=0)
-    [la,d] = np.shape(A)
-    [lb,d] = np.shape(B)
-    DP = np.zeros((la,lb))
-    DP1 = np.zeros((la,lb));
-    DP2 = np.zeros(max(la,lb));
-    l=min(la,lb);
-    DP2[1]=1.0;
-    for i in range(1,l):
-        DP2[i] = local_kernel[i-1,i-1];
+    """
+    # input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # input local_kernel: matrix of local kernel evaluations
+    """
+    d = np.shape(A)[1]
+    Z = [np.zeros(d)]
+    A = np.concatenate((Z, A), axis=0)
+    B = np.concatenate((Z, B), axis=0)
+    [la, d] = np.shape(A)
+    [lb, d] = np.shape(B)
+    DP = np.zeros((la, lb))
+    DP1 = np.zeros((la, lb))
+    DP2 = np.zeros(max(la, lb))
+    l = min(la, lb)
+    DP2[1] = 1.0
+    for i in range(1, l):
+        DP2[i] = local_kernel[i - 1, i - 1]
 
-    DP[0,0] = 1;
-    DP1[0,0] = 1;
-    n = len(A);
-    m = len(B);
+    DP[0, 0] = 1
+    DP1[0, 0] = 1
+    n = len(A)
+    m = len(B)
 
-    for i in range(1,n):
-        DP[i,1] = DP[i-1,1]*local_kernel[i-1,2];
-        DP1[i,1] = DP1[i-1,1]*DP2[i];
+    for i in range(1, n):
+        DP[i, 1] = DP[i - 1, 1] * local_kernel[i - 1, 2]
+        DP1[i, 1] = DP1[i - 1, 1] * DP2[i]
 
-    for j in range(1,m):
-        DP[1,j] = DP[1,j-1]*local_kernel[2,j-1];
-        DP1[1,j] = DP1[1,j-1]*DP2[j];
+    for j in range(1, m):
+        DP[1, j] = DP[1, j - 1] * local_kernel[2, j - 1]
+        DP1[1, j] = DP1[1, j - 1] * DP2[j]
 
-    for i in range(1,n):
-        for j in range(1,m): 
-            lcost=local_kernel[i-1,j-1];
-            DP[i,j] = (DP[i-1,j] + DP[i,j-1] + DP[i-1,j-1]) * lcost;
+    for i in range(1, n):
+        for j in range(1, m):
+            lcost = local_kernel[i - 1, j - 1]
+            DP[i, j] = (DP[i - 1, j] + DP[i, j - 1] + DP[i - 1, j - 1]) * lcost
             if i == j:
-                DP1[i,j] = DP1[i-1,j-1] * lcost + DP1[i-1,j] * DP2[i] + DP1[i,j-1]  *DP2[j]
+                DP1[i, j] = (
+                    DP1[i - 1, j - 1] * lcost
+                    + DP1[i - 1, j] * DP2[i]
+                    + DP1[i, j - 1] * DP2[j]
+                )
             else:
-                DP1[i,j] = DP1[i-1,j] * DP2[i] + DP1[i,j-1] * DP2[j];
-    DP = DP + DP1;
-    return DP[n-1,m-1]
+                DP1[i, j] = DP1[i - 1, j] * DP2[i] + DP1[i, j - 1] * DP2[j]
+    DP = DP + DP1
+    return DP[n - 1, m - 1]
 
 
-
-
-''''
-# function kdtw(A, B, sigma, epsilon)
-# Dynamic programming implementation of KDTW kernel
-# input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
-# input sigma: >0, used in the exponential local kernel 
-# input epsilon: 1 > epsilon > 0, used in the exponential local kernel 
-# output similarity: similarity between A and B (the higher, the more similar)
-'''
-def kdtw(A, B, sigma = 1.0, epsilon = 1e-3):
-    distance = cdist(A, B, 'sqeuclidean')
-    local_kernel = (np.exp(-distance/sigma)+epsilon)/(3*(1+epsilon))
-    return kdtw_lk(A,B,local_kernel)
+def kdtw(A, B, sigma=1.0, epsilon=1e-3):
+    """
+    # function kdtw(A, B, sigma, epsilon)
+    # Dynamic programming implementation of KDTW kernel
+    # input A: first multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # intput B: second multivariate time series: array of array (nxd), n is the number of sample, d is the dimension of each sample
+    # input sigma: >0, used in the exponential local kernel
+    # input epsilon: 1 > epsilon > 0, used in the exponential local kernel
+    # output similarity: similarity between A and B (the higher, the more similar)
+    """
+    distance = cdist(A, B, "sqeuclidean")
+    local_kernel = (np.exp(-distance / sigma) + epsilon) / (3 * (1 + epsilon))
+    return kdtw_lk(A, B, local_kernel)
 
 
 # Simple test
-if __name__ == '__main__':
+if __name__ == "__main__":
     import matplotlib.pyplot as plt
-    A = np.array([[0],[0],[1],[1],[2],[3],[5],[2],[0],[1],[-0.1]])
-    B = np.array([[0],[1],[2],[2.5],[3],[3.5],[4],[4.5],[5.5],[2],[0],[0],[.25],[.05],[0]])
-    C = np.array([[4],[4],[3],[3],[3],[3],[2],[5],[2],[.5],[.5],[.5]])
-    
-    print("kdtw(A,B)=", kdtw(A,B,1))
-    print("kdtw(A,C)=", kdtw(A,C,1))
-    print("kdtw(B,C)=", kdtw(B,C,1))
-        
-    plt.plot(A, label='A')
-    plt.plot(B, label='B')
-    plt.plot(C, label='C')
+
+    A = np.array([[0], [0], [1], [1], [2], [3], [5], [2], [0], [1], [-0.1]])
+    B = np.array(
+        [
+            [0],
+            [1],
+            [2],
+            [2.5],
+            [3],
+            [3.5],
+            [4],
+            [4.5],
+            [5.5],
+            [2],
+            [0],
+            [0],
+            [0.25],
+            [0.05],
+            [0],
+        ]
+    )
+    C = np.array([[4], [4], [3], [3], [3], [3], [2], [5], [2], [0.5], [0.5], [0.5]])
+
+    print("kdtw(A,B)=", kdtw(A, B, 1))
+    print("kdtw(A,C)=", kdtw(A, C, 1))
+    print("kdtw(B,C)=", kdtw(B, C, 1))
+
+    plt.plot(A, label="A")
+    plt.plot(B, label="B")
+    plt.plot(C, label="C")
     plt.legend()
     plt.show()


### PR DESCRIPTION
I compared the results of the `kdtw` Python functions to the results from the Matlab-implementation from your website: https://people.irisa.fr/Pierre-Francois.Marteau/REDK/KDTW/KDTW.html
Unfortunately, the output was inconsistent because there were some indexing bugs in the Python implementation.

This PR fixes those indexing errors and removes some unnecessary operations.

---

My setup also improved the formatting of the files. If you want to see the diffs regarding the logic changes, you can look at the commits 5f4dea2040e047f92bc675ca16fd61d364e0982b and 622e28c4fc0606a982630043efee81fd710bf044.